### PR TITLE
Remove `http:` scheme from match patterns in `content_scripts`.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,6 @@
   "content_scripts": [
     {
       "matches": [
-        "http://*/*",
         "https://*/*"
       ],
       "js": [


### PR DESCRIPTION
It may help attackers that try Men-In-Middle.

I've not tested enough but.
Web pages may be overwritten in case a user accesses the Net via cracked HTTP-proxy.
Specifically, his/her send requests may be hacked.
I see he/she can check by the pop-up by Mpurse. But major people don't check it carefully, right? ;-)